### PR TITLE
Bump signed url duration to 24h

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "exam-archive-backend",
-  "version": "0.2.0",
+  "name": "exam-archive-new",
+  "version": "1.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exam-archive-new",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "main": "src/index.ts",
   "author": "cxcorp",
   "license": "MIT",

--- a/src/download.ts
+++ b/src/download.ts
@@ -12,6 +12,7 @@ const cfSigner = new AWS.CloudFront.Signer(
 
 // age in seconds
 const oneHourToSeconds = 60 * 60 * 1
+const oneDayToSeconds = oneHourToSeconds * 24
 
 const getCloudFrontUrl = (exam: DbExam) =>
   `https://${config.AWS_CF_DISTRIBUTION_DOMAIN}/${exam.file_path}`
@@ -19,7 +20,7 @@ const getCloudFrontUrl = (exam: DbExam) =>
 const getCfSigningOptions = (
   exam: DbExam
 ): AWS.CloudFront.Signer.SignerOptionsWithoutPolicy => ({
-  expires: Math.floor(new Date().getTime() / 1000) + oneHourToSeconds,
+  expires: Math.floor(new Date().getTime() / 1000) + oneDayToSeconds,
   url: getCloudFrontUrl(exam)
 })
 


### PR DESCRIPTION
CloudFront is showing lots of 400 errors (almost 50%!!!!). Increase signed URL validity time from one hour to one day.

![image](https://user-images.githubusercontent.com/21111572/110592390-e608cc80-8182-11eb-9e08-4d5b1399a3ff.png)
