### PR TITLE
Implement exam filename renaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1346,9 +1346,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "aws-sdk": {
-      "version": "2.713.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.713.0.tgz",
-      "integrity": "sha512-axR1eOVn134KXJc1IT+Au2TXcK6oswY+4nvGe5GfU3pXeehhe0xNeP9Bw9yF36TRBxuvu4IJ2hRHDKma05smgA==",
+      "version": "2.872.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.872.0.tgz",
+      "integrity": "sha512-hI1/iwR1uPbuulvWZmCCmLKN1Oiv+Beutwcn+7ZOsWAEtsgsXiHmuRDS/ZdWiBRNQkfZgUhcCwLz7nOrWKpb8w==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -1440,9 +1440,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-auth": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "seed-s3-from-db": "cross-env NODE_ENV=development node scripts/seed-s3-from-db.js"
   },
   "dependencies": {
-    "aws-sdk": "^2.713.0",
+    "aws-sdk": "^2.872.0",
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
     "classnames": "^2.2.6",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -19,7 +19,9 @@ import {
   findCourseByName,
   createExam,
   createCourse,
-  renameCourse
+  renameCourse,
+  getExamFileNameById,
+  renameExamFile
 } from './service/archive'
 import s3 from './service/s3'
 import { AuthData, requireRights } from './common'
@@ -206,6 +208,67 @@ router.post(
 
     req.flash(`Exam ${file.originalname} created!`, 'info')
     res.redirect(urlForCourse(course.id, course.name))
+  }
+)
+
+router.post(
+  `/archive/rename-exam/:examId(\\d+)`,
+  requireRights('rename'),
+  async (req, res) => {
+    try {
+      if (!req.body.name) {
+        return res.status(400).json({ error: 'name missing' })
+      }
+
+      const examId = parseInt(req.params.examId, 10)
+      if (isNaN(examId)) {
+        return res.status(404).json({ error: 'invalid exam id' })
+      }
+
+      const oldName = await getExamFileNameById(examId)
+
+      if (oldName === null) {
+        return res.status(404).json({ error: 'exam not found' })
+      }
+
+      const updatedExam = await renameExamFile(examId, req.body.name)
+      if (updatedExam === null) {
+        console.error(
+          new Error(`Exam renaming didn't update any exams! Exam ID: ${examId}`)
+        )
+        return res.status(500).json({ error: 'error' })
+      }
+
+      // To change the Content Disposition header on S3, we need to make a copy of the
+      // object
+      const s3key = updatedExam.filePath
+      try {
+        await s3
+          .copyObject({
+            CopySource: `${config.AWS_S3_BUCKET_ID}/${s3key}`,
+            Bucket: config.AWS_S3_BUCKET_ID,
+            Key: s3key,
+            ACL: 'private',
+            ContentType: updatedExam.mimeType,
+            ContentDisposition: contentDisposition(updatedExam.fileName, {
+              type: 'inline',
+              fallback: transliterate(updatedExam.fileName)
+            }),
+            MetadataDirective: 'REPLACE'
+          })
+          .promise()
+      } catch (e) {
+        // s3 failed! revert!
+        await renameExamFile(examId, oldName)
+        console.error('S3 rename failed!', e)
+        throw e
+      }
+
+      return res.status(200).json({ ok: true })
+    } catch (e) {
+      console.error(e)
+      res.status(500).json({ error: 'internal server error' })
+    }
   }
 )
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,7 +3,6 @@ import bodyParser from 'body-parser'
 import slugify from 'slugify'
 import multer from 'multer'
 import multerS3 from 'multer-s3'
-import AWS from 'aws-sdk'
 import { transliterate } from 'transliteration'
 import contentDisposition from 'content-disposition'
 import { v4 as uuidv4 } from 'uuid'
@@ -22,6 +21,7 @@ import {
   createCourse,
   renameCourse
 } from './service/archive'
+import s3 from './service/s3'
 import { AuthData, requireRights } from './common'
 import devRouter from './dev-controller'
 
@@ -32,8 +32,6 @@ const slugifyCourseName = (courseName: string) => {
     remove: /[^\w\d \-]/g
   })
 }
-
-const s3 = new AWS.S3({ apiVersion: '2006-03-01' })
 
 const applyDevPrefix = (objectName: string) =>
   config.AWS_S3_DEV_PREFIX

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -43,6 +43,7 @@ const upload = multer({
     s3,
     bucket: config.AWS_S3_BUCKET_ID,
     contentType: multerS3.AUTO_CONTENT_TYPE,
+    acl: 'private',
     key: (
       req: any,
       file: Express.MulterS3.File,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import morgan from 'morgan'
 import path from 'path'
 const MemoryStore = require('memorystore')(session)
 import cookieParser from 'cookie-parser'
-import AWS from 'aws-sdk'
 
 import config from './config'
 import * as db from './db'
@@ -18,18 +17,6 @@ import {
   getMe
 } from './service/tkoUserService'
 import { isActiveMember, AuthData, roleRights, requireRights } from './common'
-
-if (process.env.NODE_ENV === 'development') {
-  AWS.config.update({
-    region: config.AWS_REGION,
-    accessKeyId: config.AWS_ACCESS_KEY_ID,
-    secretAccessKey: config.AWS_SECRET_ACCESS_KEY
-  })
-} else {
-  AWS.config.update({
-    region: config.AWS_REGION
-  })
-}
 
 const app = express()
 

--- a/src/service/archive.ts
+++ b/src/service/archive.ts
@@ -4,12 +4,14 @@ import {
   CourseListItem,
   ExamListItem,
   CourseId,
-  ExamId
+  ExamId,
+  Exam
 } from './common'
 import {
   deserializeCourseListItem,
   deserializeCourse,
-  deserializeExamListItem
+  deserializeExamListItem,
+  deserializeExam
 } from './dbDeserializer'
 
 const isNull = (obj: any): obj is null => obj === null
@@ -186,6 +188,37 @@ export const findCourseByExamId = async (
   }
 
   return deserializeCourse(course)
+}
+
+export const getExamFileNameById = async (
+  examId: ExamId
+): Promise<string | null> => {
+  const exam = await knex('exams')
+    .select('file_name')
+    .where({ id: examId, ...whereNotDeleted() })
+    .first()
+
+  if (!exam) {
+    return null
+  }
+
+  return exam.file_name
+}
+
+export const renameExamFile = async (
+  examId: ExamId,
+  newFilename: string
+): Promise<Exam | null> => {
+  const updatedRows: any[] = await knex('exams')
+    .update({ file_name: newFilename })
+    .where({
+      id: examId,
+      ...whereNotDeleted()
+    })
+    .returning('*')
+
+  const updatedExam = updatedRows[0]
+  return deserializeExam(updatedExam)
 }
 
 interface ExamSubmission {

--- a/src/service/common.ts
+++ b/src/service/common.ts
@@ -22,3 +22,12 @@ export interface ExamListItem {
   mimeType: string
   uploadDate: Date
 }
+
+export interface Exam {
+  id: ExamId
+  courseId: CourseId
+  fileName: string
+  mimeType: string
+  filePath: string
+  uploadDate: Date
+}

--- a/src/service/dbDeserializer.ts
+++ b/src/service/dbDeserializer.ts
@@ -1,4 +1,4 @@
-import { Course, CourseListItem, ExamListItem } from './common'
+import { Course, CourseListItem, Exam, ExamListItem } from './common'
 
 // created_at and uploaded_at are missing because we aren't using them
 interface DbCourse {
@@ -16,6 +16,15 @@ interface DbExamListItem {
   file_name: string
   mime_type: string
   // file_path omitted, not public info
+  upload_date: Date
+}
+
+interface DbExam {
+  id: number
+  course_id: number
+  file_name: string
+  mime_type: string
+  file_path: string
   upload_date: Date
 }
 
@@ -38,6 +47,14 @@ const courseChecks = [
   (obj: any) => typeof obj.name === 'string'
 ]
 const courseListItemChecks = [...courseChecks, lastModifiedIsNullOrDate]
+const examListItemChecks = [
+  (obj: any) => !!obj,
+  (obj: any) => typeof obj.id === 'number',
+  (obj: any) => typeof obj.course_id === 'number',
+  (obj: any) => typeof obj.file_name === 'string',
+  (obj: any) => typeof obj.mime_type === 'string',
+  (obj: any) => obj.upload_date instanceof Date
+]
 const examChecks = [
   (obj: any) => !!obj,
   (obj: any) => typeof obj.id === 'number',
@@ -50,7 +67,8 @@ const examChecks = [
 
 const isCourse = createValidator<DbCourse>(courseChecks)
 const isCourseListItem = createValidator<DbCourseListItem>(courseListItemChecks)
-const isExamListItem = createValidator<DbExamListItem>(examChecks)
+const isExamListItem = createValidator<DbExamListItem>(examListItemChecks)
+const isExam = createValidator<DbExam>(examChecks)
 
 export const deserializeCourseListItem = (obj: any): CourseListItem | null => {
   if (!isCourseListItem(obj)) {
@@ -83,6 +101,21 @@ export const deserializeExamListItem = (obj: any): ExamListItem | null => {
     courseId: obj.course_id,
     fileName: obj.file_name,
     mimeType: obj.mime_type,
+    uploadDate: obj.upload_date
+  }
+}
+
+export const deserializeExam = (obj: any): Exam | null => {
+  if (!isExam(obj)) {
+    return null
+  }
+
+  return {
+    id: obj.id,
+    courseId: obj.course_id,
+    fileName: obj.file_name,
+    mimeType: obj.mime_type,
+    filePath: obj.file_path,
     uploadDate: obj.upload_date
   }
 }

--- a/src/service/s3.ts
+++ b/src/service/s3.ts
@@ -1,0 +1,20 @@
+import AWS from 'aws-sdk'
+import config from '../config'
+
+if (config.NODE_ENV === 'development') {
+  AWS.config.update({
+    region: config.AWS_REGION,
+    credentials: {
+      accessKeyId: config.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: config.AWS_SECRET_ACCESS_KEY!
+    }
+  })
+} else {
+  AWS.config.update({
+    region: config.AWS_REGION
+  })
+}
+
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' })
+
+export default s3

--- a/src/views/course.jsx
+++ b/src/views/course.jsx
@@ -5,18 +5,20 @@ const fiLocale = require('date-fns/locale/fi')
 const Layout = require('./common/Layout')
 const { ControlsBox, Logout } = require('./common/Controls')
 
-const ExamTableHeader = ({ showDelete }) => {
+const ExamTableHeader = ({ showDelete, showRename }) => {
   return (
     <tr className="exam-table-header">
       <th>Name</th>
       <th>Last modified</th>
       {showDelete && <th>Delete</th>}
+      {showRename && <th>Rename</th>}
     </tr>
   )
 }
 
 ExamTableHeader.propTypes = {
-  showDelete: PropTypes.bool
+  showDelete: PropTypes.bool,
+  showRename: PropTypes.bool
 }
 
 const mimeTypeImage = mimeType => {
@@ -56,7 +58,7 @@ DeleteExamButton.propTypes = {
 
 const makeDeleteExamAction = examId => `/archive/delete-exam/${examId}`
 
-const ExamTableRow = ({ exam, showDelete }) => {
+const ExamTableRow = ({ exam, showDelete, showRename }) => {
   const { id, fileName, mimeType, uploadDate, downloadUrl } = exam
 
   return (
@@ -83,6 +85,18 @@ const ExamTableRow = ({ exam, showDelete }) => {
           <DeleteExamButton action={makeDeleteExamAction(id)} />
         </td>
       )}
+      {showRename && (
+        <td className="exam-table-row__rename">
+          <button
+            /* augments.js */
+            data-current-name={fileName}
+            data-id={id}
+            className="exam-table-row__rename-button"
+          >
+            rename
+          </button>
+        </td>
+      )}
     </tr>
   )
 }
@@ -96,7 +110,8 @@ const examShape = PropTypes.shape({
 
 ExamTableRow.propTypes = {
   exam: examShape.isRequired,
-  showDelete: PropTypes.bool
+  showDelete: PropTypes.bool,
+  showRename: PropTypes.bool
 }
 
 const GoBackRow = ({ href }) => {
@@ -118,16 +133,21 @@ GoBackRow.propTypes = {
   href: PropTypes.string.isRequired
 }
 
-const ExamTable = ({ exams, previousPageUrl, showDelete }) => {
+const ExamTable = ({ exams, previousPageUrl, showDelete, showRename }) => {
   return (
     <table className="exam-table">
       <thead>
-        <ExamTableHeader showDelete={showDelete} />
+        <ExamTableHeader showDelete={showDelete} showRename={showRename} />
       </thead>
       <tbody>
         <GoBackRow href={previousPageUrl} />
         {exams.map(exam => (
-          <ExamTableRow key={exam.id} exam={exam} showDelete={showDelete} />
+          <ExamTableRow
+            key={exam.id}
+            exam={exam}
+            showDelete={showDelete}
+            showRename={showRename}
+          />
         ))}
       </tbody>
     </table>
@@ -137,7 +157,8 @@ const ExamTable = ({ exams, previousPageUrl, showDelete }) => {
 ExamTable.propTypes = {
   exams: PropTypes.arrayOf(examShape.isRequired).isRequired,
   previousPageUrl: PropTypes.string.isRequired,
-  showDelete: PropTypes.bool
+  showDelete: PropTypes.bool,
+  showRename: PropTypes.bool
 }
 
 const UploadExamForm = ({ courseId }) => {
@@ -186,6 +207,7 @@ const CoursePage = ({
         exams={exams}
         previousPageUrl={previousPageUrl}
         showDelete={userRights.remove}
+        showRename={userRights.rename}
       />
 
       <ControlsBox>

--- a/static/augments.js
+++ b/static/augments.js
@@ -40,6 +40,48 @@ function attachCourseRenameHandlers() {
   })
 }
 
+function attachExamRenameHandlers() {
+  ;[
+    ...document.getElementsByClassName('exam-table-row__rename-button')
+  ].forEach(button => {
+    button.addEventListener('click', e => {
+      e.preventDefault()
+      const { id, currentName } = button.dataset
+      const res = prompt(
+        `Please enter the new filename for this exam:`,
+        currentName
+      )
+      if (!res) {
+        return
+      }
+
+      const formData = new URLSearchParams()
+      formData.append('name', res)
+
+      return fetch(`/archive/rename-exam/${encodeURI(id)}`, {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin'
+      })
+        .then(res => {
+          if (res.status === 200) {
+            location.reload()
+            return
+          }
+          if (res.status === 404) {
+            alert('Course not found!')
+            return
+          }
+          alert('An error occurred.')
+        })
+        .catch(e => {
+          console.error(e)
+          alert('An error occurred.')
+        })
+    })
+  })
+}
+
 function attachExamDeleteConfirmationHandlers() {
   ;[...document.getElementsByClassName('delete-exam-button')].forEach(
     deleteForm => {
@@ -57,4 +99,5 @@ function attachExamDeleteConfirmationHandlers() {
 }
 
 attachCourseRenameHandlers()
+attachExamRenameHandlers()
 attachExamDeleteConfirmationHandlers()


### PR DESCRIPTION
Closes #19

Adds a new button for exam files - `rename`. Renames the `file_name` for the exam in the database, and updates the S3 object's `Content-Disposition` header. The old header is still cached by CloudFront for some time, but if it becomes a problem, we can just generate a new UUID (`file_path`) when doing the S3 copyObject operation (metadata can only be changed when uploading/copying, so it requires a copy operation anyways).

Access to rename is given to administrators and exam archive managers. Can change in the future if needed.